### PR TITLE
Use wait_until_ready over on_ready

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -68,13 +68,15 @@ class HelpFormat(DefaultHelpCommand):
 class Bot(AutoShardedBot):
     def __init__(self, *args, prefix=None, **kwargs):
         super().__init__(*args, help_command=HelpFormat(), **kwargs)
+        self.loop.create_task(ready())
 
         for ext in init_extensions:
             self.load_extension(ext)
 
         self.boot_time = datetime.now()
 
-    async def on_ready(self):
+    async def ready(self):
+        await self.wait_until_ready()
         print(f"Ready : {self.user.name} -- {self.user.id}")
         print(f"Shards : {self.shard_count}")
         await self.change_presence(status=discord.Status.online, activity=discord.Game("!help"))


### PR DESCRIPTION
# Why wait_until_ready over on_ready
Hey there! I noticed you had the `on_ready()` listener implemented. Doing anything `on_ready()` is generally not good practice, as stated here on the [discord.py documentation page for `on_ready()`](https://discordpy.readthedocs.io/en/latest/api.html?highlight=wait_until_ready#discord.on_ready). Instead, I've implemented `wait_until_ready()`, which is better practice, and will prevent issues like random disconnects or the event firing multiple times from happening.